### PR TITLE
Select with continuation fixed.

### DIFF
--- a/src/mnesia_leveled.app.src
+++ b/src/mnesia_leveled.app.src
@@ -1,7 +1,7 @@
 {application, mnesia_leveled,
  [
   {description, "Leveled backend plugin for Mnesia"},
-  {vsn, "1.0"},
+  {vsn, git},
   {modules, [mnesia_leveled, mnesia_leveled_app,
              mnesia_leveled_params, mnesia_leveled_sup,
              mnesia_leveled_tuning]},


### PR DESCRIPTION
The fix was needed, because the select/fold was
traversing the entire table. That caused out of
memory errors when mnesia synchronizes its tables
between nodes on startup.

Logging is also improved a bit.