### PR TITLE
Use latest leveled; Fix compiler warning in OTP 22, 23

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,8 @@
 {deps,
  [
   {sext, "1.5.0"},
-  {leveled, {git, "https://github.com/martinsumner/leveled.git", {ref, "4b967be"}}}
+  {leveled, {git, "https://github.com/martinsumner/leveled.git",
+             {ref,"5bc137e4ef90d55f1e0da216a5ef5801d2a3d813"}}}
  ]}.
 
 {profiles,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,11 @@
 {"1.1.0",
 [{<<"leveled">>,
   {git,"https://github.com/martinsumner/leveled.git",
-       {ref,"4b967bee4aebe0ee170d47a4e0119e7fde620a03"}},
+       {ref,"5bc137e4ef90d55f1e0da216a5ef5801d2a3d813"}},
   0},
  {<<"lz4">>,
-  {git,"https://github.com/szktty/erlang-lz4",
-       {ref,"6bc5efe93bab327788bcde24374f16044b549dd8"}},
+  {git,"https://github.com/martinsumner/erlang-lz4",
+       {ref,"d407af5de71303b8e381df718d2e5d05eb775c59"}},
   1},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.5.0">>},0}]}.
 [


### PR DESCRIPTION
Related to aeternity/aeternity#3293, we upgrade to the latest version of [leveled](https://github.com/martinsumner/leveled), which builds cleanly on OTP 22 and 23. We also update the debug code using stacktraces, so that we don't get compiler warnings in OTP versions 21 and higher.